### PR TITLE
Fix uuid's not saving correctly

### DIFF
--- a/src/main/java/ca/wacos/nametagedit/NametagCommand.java
+++ b/src/main/java/ca/wacos/nametagedit/NametagCommand.java
@@ -284,7 +284,7 @@ public class NametagCommand implements CommandExecutor {
             String uuid = target.getUniqueId().toString();
 
             if (!plugin.getNteHandler().getPlayerData().containsKey(uuid)) {
-                plugin.getNteHandler().getPlayerData().put(uuid, new PlayerData(uuid, targetName, "", ""));
+                plugin.getNteHandler().getPlayerData().put(uuid, new PlayerData(targetName, uuid, "", ""));
             } else {
                 PlayerData data = plugin.getNteHandler().getPlayerData().get(uuid);
 


### PR DESCRIPTION
I noticed that when doing /ne prefix <playername> and then reloading from file/memory it would remove the tag and the config would look like this, which is wrong since your plugin reads Players.uuid and not Players.name http://hastebin.com/haqicatuze.vbs, This fixes that issue so the uuid is assigned as the uuid