### PR TITLE
Add LuckPerms hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
             <scope>system</scope>
             <systemPath>${basedir}/lib/EssentialsGroupManager.jar</systemPath>
         </dependency>
+        <!-- LuckPerms -->
+        <dependency>
+            <groupId>me.lucko.luckperms</groupId>
+            <artifactId>luckperms-api</artifactId>
+            <version>3.2</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- HikariCP -->
         <dependency>
             <groupId>com.zaxxer</groupId>
@@ -67,7 +74,7 @@
         <dependency>
             <groupId>be.maximvdw</groupId>
             <artifactId>MVdWPlaceholderAPI</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <!-- Clip Placeholder API -->
         <dependency>
@@ -111,6 +118,11 @@
         <repository>
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+        <!-- Luck Repo -->
+        <repository>
+            <id>luck-repo</id>
+            <url>https://repo.lucko.me/</url>
         </repository>
     </repositories>
     <!-- Builds NametagEdit -->
@@ -159,8 +171,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/nametagedit/plugin/NametagEdit.java
+++ b/src/main/java/com/nametagedit/plugin/NametagEdit.java
@@ -4,6 +4,7 @@ import com.nametagedit.plugin.api.INametagApi;
 import com.nametagedit.plugin.api.NametagAPI;
 import com.nametagedit.plugin.hooks.HookGroupManager;
 import com.nametagedit.plugin.hooks.HookLibsDisguise;
+import com.nametagedit.plugin.hooks.HookLuckPerms;
 import com.nametagedit.plugin.hooks.HookPermissionsEX;
 import com.nametagedit.plugin.hooks.HookZPermissions;
 import com.nametagedit.plugin.metrics.Metrics;
@@ -54,6 +55,8 @@ public class NametagEdit extends JavaPlugin {
             pluginManager.registerEvents(new HookPermissionsEX(handler), this);
         } else if (checkShouldRegister("GroupManager")) {
             pluginManager.registerEvents(new HookGroupManager(handler), this);
+        } else if (checkShouldRegister("LuckPerms")) {
+            new HookLuckPerms(handler).register();
         }
 
         if (pluginManager.getPlugin("LibsDisguises") != null) {

--- a/src/main/java/com/nametagedit/plugin/hooks/HookLuckPerms.java
+++ b/src/main/java/com/nametagedit/plugin/hooks/HookLuckPerms.java
@@ -1,0 +1,29 @@
+package com.nametagedit.plugin.hooks;
+
+import com.nametagedit.plugin.NametagHandler;
+import lombok.AllArgsConstructor;
+import me.lucko.luckperms.api.LuckPermsApi;
+import me.lucko.luckperms.api.event.user.UserDataRecalculateEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+@AllArgsConstructor
+public class HookLuckPerms {
+
+    private NametagHandler handler;
+
+    public void register() {
+        LuckPermsApi api = Bukkit.getServicesManager().getRegistration(LuckPermsApi.class).getProvider();
+        api.getEventBus().subscribe(UserDataRecalculateEvent.class, this::onDataRecalculate);
+    }
+
+    private void onDataRecalculate(UserDataRecalculateEvent event) {
+        Bukkit.getScheduler().runTask(handler.getPlugin(), () -> {
+            Player player = Bukkit.getPlayer(event.getUser().getUuid());
+            if (player != null) {
+                handler.applyTagToPlayer(player);
+            }
+        });
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: NametagEdit
 main: com.nametagedit.plugin.NametagEdit
 version: 4.1.4
 authors: [sgtcaze, Cory]
-soft-depend: [zPermissions, PermissionsEX, GroupManager, LibsDisguises]
+soft-depend: [zPermissions, PermissionsEX, GroupManager, LuckPerms, LibsDisguises]
 commands:
   ne:
     description: NametagEdit commands


### PR DESCRIPTION
This pull request adds support for LuckPerms. We just switched to it from zPermissions on our server, since the latter doesn't work on the new pre-release. 😄 

I tried to keep the code style the same as with the other hook classes in that package. The only real difference is that LuckPerms has it's own event listening system (I guess because it's multi-platform), so the NametagEdit listener has to be registered directly.

I also had to bump the target & source level to 1.8, since the API uses `java.util.function.Consumer`. This really shouldn't be a problem, since the vast majority of servers are running Java 8 already, and the few remaining hosts are being forced to update in 1.12 anyway.

I tested my changes locally and all seems to work well.

(also: I had to bump the MVdWPlaceholderAPI version to get it to compile, the previous artifact seems to have disappeared from the Maven repo!)