### PR TITLE
Added a new 'type/group' of incompatible plugins for the new scoreboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ NametagEdit has support for EssentialsGroupManager, PermissionsEx and zPermissio
 
 # Incompatible Plugins
 ✖ Any plugin that creates NPCs that share the same username as players who have 'NametagEdit' nametags
+✖ Any plugin that uses Team color sidebars without specifically supporting NametagEdit


### PR DESCRIPTION
Added a new 'group' of incompatible plugins - this change will become more prominent with the new spigot scoreboard API in 1.13. However it is also a problem with NMS based plugins.
Any plugin that creates team color sidebars will not work - since a player can only be in one team. They have to hook into NTE and get the name of the team the player is in