### PR TITLE
1.13.x and backwards compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,178 +1,186 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>com.nametagedit</groupId>
-    <artifactId>nametagedit</artifactId>
-    <version>4.1.0</version>
-    <packaging>jar</packaging>
-    <name>NametagEdit</name>
-    <url>http://maven.apache.org</url>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <dependencies>
-        <!--Spigot API-->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!--Bukkit API -->
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- PermissionsEx-->
-        <dependency>
-            <groupId>ninja.leaping.permissionsex</groupId>
-            <artifactId>permissionsex-parent</artifactId>
-            <version>2.0-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/PermissionsEx.jar</systemPath>
-        </dependency>
-        <!-- zPermissions -->
-        <dependency>
-            <groupId>org.tyrannyofheaven.bukkit</groupId>
-            <artifactId>zPermissions</artifactId>
-            <version>1.3-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/zPermissions.jar</systemPath>
-        </dependency>
-        <!-- EssentialsGroupManager-->
-        <dependency>
-            <groupId>org.anjocaido.groupmanager</groupId>
-            <artifactId>EssentialsGroupManager</artifactId>
-            <version>2.x-SNAPSHOT</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/EssentialsGroupManager.jar</systemPath>
-        </dependency>
-        <!-- LuckPerms -->
-        <dependency>
-            <groupId>me.lucko.luckperms</groupId>
-            <artifactId>luckperms-api</artifactId>
-            <version>4.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- MVdW Placeholder API-->
-        <dependency>
-            <groupId>be.maximvdw</groupId>
-            <artifactId>MVdWPlaceholderAPI</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
-            <!--<version>2.1.1-SNAPSHOT</version>-->
-            <scope>provided</scope>
-        </dependency>
-        <!-- Clip Placeholder API -->
-        <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>2.8.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- LibsDisguises -->
-        <dependency>
-            <groupId>LibsDisguises</groupId>
-            <artifactId>LibsDisguises</artifactId>
-            <version>9.0.7</version>
-            <scope>system</scope>
-            <systemPath>${basedir}/lib/LibsDisguises-9.0.9.jar</systemPath>
-        </dependency>
-        <!-- HikariCP -->
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>2.6.0</version>
-        </dependency>
-        <!-- SL4J -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.24</version>
-            <scope>compile</scope>
-        </dependency>
-        <!-- Lombok -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.14.8</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-    <repositories>
-        <!-- Spigot -->
-        <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <!-- MVdW Repo -->
-        <repository>
-            <id>mvdw-software</id>
-            <name>MVdW Public Repositories</name>
-            <url>http://repo.mvdw-software.be/content/groups/public/</url>
-        </repository>
-        <!-- Clip Repo -->
-        <repository>
-            <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-    </repositories>
-    <!-- Builds NametagEdit -->
-    <build>
-        <defaultGoal>clean package</defaultGoal>
-        <finalName>NametagEdit</finalName>
-        <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
-        <resources>
-            <resource>
-                <targetPath>.</targetPath>
-                <filtering>false</filtering>
-                <directory>${basedir}/src/main/resources/</directory>
-                <includes>
-                    <include>*.*</include>
-                </includes>
-            </resource>
-        </resources>
-        <plugins>
-            <!-- Shade all Libs -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <minimizeJar>true</minimizeJar>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.slf4j:*</include>
-                                    <include>com.zaxxer:*</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Make a Jar -->
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-            </plugin>
-        </plugins>
-    </build>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://maven.apache.org/POM/4.0.0"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		<modelVersion>4.0.0</modelVersion>
+		<groupId>com.nametagedit</groupId>
+		<artifactId>nametagedit</artifactId>
+		<version>4.3.0</version>
+		<packaging>jar</packaging>
+		<name>NametagEdit</name>
+		<url>http://maven.apache.org</url>
+		<properties>
+				<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+				<spigot.version>1.12.2-R0.1-SNAPSHOT</spigot.version>
+		</properties>
+		<dependencies>
+				<!--Spigot API -->
+				<dependency>
+						<groupId>org.spigotmc</groupId>
+						<artifactId>spigot-api</artifactId>
+						<version>${spigot.version}</version>
+						<scope>provided</scope>
+				</dependency>
+				<!--Bukkit API -->
+				<dependency>
+						<groupId>org.bukkit</groupId>
+						<artifactId>bukkit</artifactId>
+						<version>${spigot.version}</version>
+						<scope>provided</scope>
+				</dependency>
+				<!-- PermissionsEx -->
+				<dependency>
+						<groupId>ninja.leaping.permissionsex</groupId>
+						<artifactId>permissionsex-parent</artifactId>
+						<version>2.0-SNAPSHOT</version>
+						<scope>system</scope>
+						<systemPath>${basedir}/lib/PermissionsEx.jar</systemPath>
+				</dependency>
+				<!-- zPermissions -->
+				<dependency>
+						<groupId>org.tyrannyofheaven.bukkit</groupId>
+						<artifactId>zPermissions</artifactId>
+						<version>1.3-SNAPSHOT</version>
+						<scope>system</scope>
+						<systemPath>${basedir}/lib/zPermissions.jar</systemPath>
+				</dependency>
+				<!-- EssentialsGroupManager -->
+				<dependency>
+						<groupId>org.anjocaido.groupmanager</groupId>
+						<artifactId>EssentialsGroupManager</artifactId>
+						<version>2.x-SNAPSHOT</version>
+						<scope>system</scope>
+						<systemPath>${basedir}/lib/EssentialsGroupManager.jar</systemPath>
+				</dependency>
+				<!-- LuckPerms -->
+				<dependency>
+						<groupId>me.lucko.luckperms</groupId>
+						<artifactId>luckperms-api</artifactId>
+						<version>4.0</version>
+						<scope>provided</scope>
+				</dependency>
+				<!-- MVdW Placeholder API -->
+				<dependency>
+						<groupId>be.maximvdw</groupId>
+						<artifactId>MVdWPlaceholderAPI</artifactId>
+						<version>1.0.2-SNAPSHOT</version>
+						<!--<version>2.1.1-SNAPSHOT</version> -->
+						<scope>provided</scope>
+				</dependency>
+				<!-- Clip Placeholder API -->
+				<dependency>
+						<groupId>me.clip</groupId>
+						<artifactId>placeholderapi</artifactId>
+						<version>2.8.2</version>
+						<scope>provided</scope>
+				</dependency>
+				<!-- LibsDisguises -->
+				<dependency>
+						<groupId>LibsDisguises</groupId>
+						<artifactId>LibsDisguises</artifactId>
+						<version>9.0.7</version>
+						<scope>system</scope>
+						<systemPath>${basedir}/lib/LibsDisguises-9.0.9.jar</systemPath>
+				</dependency>
+				<!-- HikariCP -->
+				<dependency>
+						<groupId>com.zaxxer</groupId>
+						<artifactId>HikariCP</artifactId>
+						<version>2.6.0</version>
+				</dependency>
+				<!-- SL4J -->
+				<dependency>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-jdk14</artifactId>
+						<version>1.7.24</version>
+						<scope>compile</scope>
+				</dependency>
+				<!-- Lombok -->
+				<dependency>
+						<groupId>org.projectlombok</groupId>
+						<artifactId>lombok</artifactId>
+						<version>1.14.8</version>
+						<scope>provided</scope>
+				</dependency>
+				<!-- Google Guava API -->
+				<dependency>
+						<groupId>com.google.guava</groupId>
+						<artifactId>guava</artifactId>
+						<version>r05</version>
+				</dependency>
+		</dependencies>
+		<repositories>
+				<!-- Spigot -->
+				<repository>
+						<id>spigot-repo</id>
+						<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+				</repository>
+				<!-- MVdW Repo -->
+				<repository>
+						<id>mvdw-software</id>
+						<name>MVdW Public Repositories</name>
+						<url>http://repo.mvdw-software.be/content/groups/public/</url>
+				</repository>
+				<!-- Clip Repo -->
+				<repository>
+						<id>placeholderapi</id>
+						<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+				</repository>
+		</repositories>
+		<!-- Builds NametagEdit -->
+		<build>
+				<defaultGoal>clean package</defaultGoal>
+				<finalName>NametagEdit</finalName>
+				<sourceDirectory>${basedir}/src/main/java</sourceDirectory>
+				<resources>
+						<resource>
+								<targetPath>.</targetPath>
+								<filtering>false</filtering>
+								<directory>${basedir}/src/main/resources/</directory>
+								<includes>
+										<include>*.*</include>
+								</includes>
+						</resource>
+				</resources>
+				<plugins>
+						<!-- Shade all Libs -->
+						<plugin>
+								<groupId>org.apache.maven.plugins</groupId>
+								<artifactId>maven-shade-plugin</artifactId>
+								<version>3.1.0</version>
+								<executions>
+										<execution>
+												<phase>package</phase>
+												<goals>
+														<goal>shade</goal>
+												</goals>
+												<configuration>
+														<minimizeJar>true</minimizeJar>
+														<createDependencyReducedPom>false</createDependencyReducedPom>
+														<artifactSet>
+																<includes>
+																		<include>org.slf4j:*</include>
+																		<include>com.zaxxer:*</include>
+																</includes>
+														</artifactSet>
+												</configuration>
+										</execution>
+								</executions>
+						</plugin>
+						<!-- Make a Jar -->
+						<plugin>
+								<artifactId>maven-compiler-plugin</artifactId>
+								<version>3.7.0</version>
+								<configuration>
+										<source>1.8</source>
+										<target>1.8</target>
+								</configuration>
+						</plugin>
+						<plugin>
+								<groupId>org.apache.maven.plugins</groupId>
+								<artifactId>maven-jar-plugin</artifactId>
+								<version>3.0.2</version>
+						</plugin>
+				</plugins>
+		</build>
 </project>

--- a/src/main/java/com/nametagedit/plugin/NametagEdit.java
+++ b/src/main/java/com/nametagedit/plugin/NametagEdit.java
@@ -1,15 +1,21 @@
 package com.nametagedit.plugin;
 
-import com.nametagedit.plugin.api.INametagApi;
-import com.nametagedit.plugin.api.NametagAPI;
-import com.nametagedit.plugin.hooks.*;
-import com.nametagedit.plugin.packets.PacketWrapper;
-import lombok.Getter;
+import java.util.ArrayList;
+
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
+import com.nametagedit.plugin.api.INametagApi;
+import com.nametagedit.plugin.api.NametagAPI;
+import com.nametagedit.plugin.hooks.HookGroupManager;
+import com.nametagedit.plugin.hooks.HookLibsDisguise;
+import com.nametagedit.plugin.hooks.HookLuckPerms;
+import com.nametagedit.plugin.hooks.HookPermissionsEX;
+import com.nametagedit.plugin.hooks.HookZPermissions;
+import com.nametagedit.plugin.packets.PacketWrapper;
+
+import lombok.Getter;
 
 /**
  * TODO:
@@ -24,7 +30,7 @@ public class NametagEdit extends JavaPlugin {
 
     private NametagHandler handler;
     private NametagManager manager;
-
+    
     public static INametagApi getApi() {
         return api;
     }
@@ -91,5 +97,5 @@ public class NametagEdit extends JavaPlugin {
                 .append("\nThe plugin will now self destruct.\n------------------------------------------------------")
                 .toString());
     }
-
+    
 }

--- a/src/main/java/com/nametagedit/plugin/NametagManager.java
+++ b/src/main/java/com/nametagedit/plugin/NametagManager.java
@@ -1,13 +1,19 @@
 package com.nametagedit.plugin;
 
-import com.nametagedit.plugin.api.data.FakeTeam;
-import com.nametagedit.plugin.packets.PacketWrapper;
-import lombok.AllArgsConstructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.util.*;
+import com.nametagedit.plugin.api.data.FakeTeam;
+import com.nametagedit.plugin.packets.PacketWrapper;
+
+import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class NametagManager {

--- a/src/main/java/com/nametagedit/plugin/packets/PacketAccessor.java
+++ b/src/main/java/com/nametagedit/plugin/packets/PacketAccessor.java
@@ -5,125 +5,142 @@ import org.bukkit.entity.Player;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 class PacketAccessor {
 
-    private static boolean CAULDRON_SERVER = false;
+	private static List<String> legacyVersions = Arrays.asList("v1_7_R1","v1_7_R2","v1_7_R3","v1_7_R4","v1_8_R1","v1_8_R2","v1_8_R3","v1_9_R1","v1_9_R2","v1_10_R1","v1_11_R1","v1_12_R1");
+	private static boolean CAULDRON_SERVER = false;
 
-    static Field MEMBERS;
-    static Field PREFIX;
-    static Field SUFFIX;
-    static Field TEAM_NAME;
-    static Field PARAM_INT;
-    static Field PACK_OPTION;
-    static Field DISPLAY_NAME;
-    static Field PUSH;
-    static Field VISIBILITY;
+	static Field MEMBERS;
+	static Field PREFIX;
+	static Field SUFFIX;
+	static Field TEAM_NAME;
+	static Field PARAM_INT;
+	static Field PACK_OPTION;
+	static Field DISPLAY_NAME;
+	static Field TEAM_COLOR;
+	static Field PUSH;
+	static Field VISIBILITY;
 
-    private static Method getHandle;
-    private static Method sendPacket;
-    private static Field playerConnection;
+	private static Method getHandle;
+	private static Method sendPacket;
+	private static Field playerConnection;
 
-    private static Class<?> packetClass;
+	private static Class<?> packetClass;
 
-    static {
-        try {
-            Class.forName("cpw.mods.fml.common.Mod");
-            CAULDRON_SERVER = true;
-        } catch (ClassNotFoundException ignored) {
-            // This is not a cauldron server
-        }
+	static {
+		try {
+			Class.forName("cpw.mods.fml.common.Mod");
+			CAULDRON_SERVER = true;
+		} catch (ClassNotFoundException ignored) {
+			// This is not a cauldron server
+		}
 
-        try {
-            String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-            Class<?> typeCraftPlayer = Class.forName("org.bukkit.craftbukkit." + version + ".entity.CraftPlayer");
-            getHandle = typeCraftPlayer.getMethod("getHandle");
+		try {
+			String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+			Class<?> typeCraftPlayer = Class.forName("org.bukkit.craftbukkit." + version + ".entity.CraftPlayer");
+			getHandle = typeCraftPlayer.getMethod("getHandle");
 
-            if (CAULDRON_SERVER) {
-                packetClass = Class.forName("net.minecraft.server.v1_7_R4.PacketPlayOutScoreboardTeam");
-                Class<?> typeNMSPlayer = Class.forName("net.minecraft.server.v1_7_R4.EntityPlayer");
-                Class<?> typePlayerConnection = Class.forName("net.minecraft.server.v1_7_R4.PlayerConnection");
-                playerConnection = typeNMSPlayer.getField("field_71135_a");
-                sendPacket = typePlayerConnection.getMethod("func_147359_a", Class.forName("net.minecraft.server.v1_7_R4.Packet"));
-            } else {
-                packetClass = Class.forName("net.minecraft.server." + version + ".PacketPlayOutScoreboardTeam");
-                Class<?> typeNMSPlayer = Class.forName("net.minecraft.server." + version + ".EntityPlayer");
-                Class<?> typePlayerConnection = Class.forName("net.minecraft.server." + version + ".PlayerConnection");
-                playerConnection = typeNMSPlayer.getField("playerConnection");
-                sendPacket = typePlayerConnection.getMethod("sendPacket", Class.forName("net.minecraft.server." + version + ".Packet"));
-            }
+			if (CAULDRON_SERVER) {
+				packetClass = Class.forName("net.minecraft.server.v1_7_R4.PacketPlayOutScoreboardTeam");
+				Class<?> typeNMSPlayer = Class.forName("net.minecraft.server.v1_7_R4.EntityPlayer");
+				Class<?> typePlayerConnection = Class.forName("net.minecraft.server.v1_7_R4.PlayerConnection");
+				playerConnection = typeNMSPlayer.getField("field_71135_a");
+				sendPacket = typePlayerConnection.getMethod("func_147359_a", Class.forName("net.minecraft.server.v1_7_R4.Packet"));
+			} else {
+				packetClass = Class.forName("net.minecraft.server." + version + ".PacketPlayOutScoreboardTeam");
+				Class<?> typeNMSPlayer = Class.forName("net.minecraft.server." + version + ".EntityPlayer");
+				Class<?> typePlayerConnection = Class.forName("net.minecraft.server." + version + ".PlayerConnection");
+				playerConnection = typeNMSPlayer.getField("playerConnection");
+				sendPacket = typePlayerConnection.getMethod("sendPacket", Class.forName("net.minecraft.server." + version + ".Packet"));
+			}
 
-            PacketData currentVersion = null;
-            for (PacketData packetData : PacketData.values()) {
-                if (version.contains(packetData.name())) {
-                    currentVersion = packetData;
+			PacketData currentVersion = null;
+			for (PacketData packetData : PacketData.values()) {
+				if (version.contains(packetData.name())) {
+					currentVersion = packetData;
+				}
+			}
+
+			if (CAULDRON_SERVER) {
+				currentVersion = PacketData.cauldron;
+			}
+
+			if (currentVersion != null) {
+				PREFIX = getNMS(currentVersion.getPrefix());
+				SUFFIX = getNMS(currentVersion.getSuffix());
+				MEMBERS = getNMS(currentVersion.getMembers());
+				TEAM_NAME = getNMS(currentVersion.getTeamName());
+				PARAM_INT = getNMS(currentVersion.getParamInt());
+				PACK_OPTION = getNMS(currentVersion.getPackOption());
+				DISPLAY_NAME = getNMS(currentVersion.getDisplayName());
+				
+				if (!isLegacyClient()) {
+                	TEAM_COLOR = getNMS(currentVersion.getColor());
                 }
-            }
 
-            if (CAULDRON_SERVER) {
-                currentVersion = PacketData.cauldron;
-            }
+				if (isPushVersion(version)) {
+					PUSH = getNMS(currentVersion.getPush());
+				}
 
-            if (currentVersion != null) {
-                PREFIX = getNMS(currentVersion.getPrefix());
-                SUFFIX = getNMS(currentVersion.getSuffix());
-                MEMBERS = getNMS(currentVersion.getMembers());
-                TEAM_NAME = getNMS(currentVersion.getTeamName());
-                PARAM_INT = getNMS(currentVersion.getParamInt());
-                PACK_OPTION = getNMS(currentVersion.getPackOption());
-                DISPLAY_NAME = getNMS(currentVersion.getDisplayName());
+				if (isVisibilityVersion(version)) {
+					VISIBILITY = getNMS(currentVersion.getVisibility());
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 
-                if (isPushVersion(version)) {
-                    PUSH = getNMS(currentVersion.getPush());
-                }
+	public static boolean isLegacyClient() {
+		String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 
-                if (isVisibilityVersion(version)) {
-                    VISIBILITY = getNMS(currentVersion.getVisibility());
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+		if (legacyVersions.contains(version) || CAULDRON_SERVER)
+			return true;
 
-    private static boolean isPushVersion(String version) {
-        return Integer.parseInt(version.split("_")[1]) >= 9;
-    }
+		return false;
+	}
 
-    private static boolean isVisibilityVersion(String version) {
-        return Integer.parseInt(version.split("_")[1]) >= 8;
-    }
+	private static boolean isPushVersion(String version) {
+		return Integer.parseInt(version.split("_")[1]) >= 9;
+	}
 
-    private static Field getNMS(String path) throws Exception {
-        Field field = packetClass.getDeclaredField(path);
-        field.setAccessible(true);
-        return field;
-    }
+	private static boolean isVisibilityVersion(String version) {
+		return Integer.parseInt(version.split("_")[1]) >= 8;
+	}
 
-    static Object createPacket() {
-        try {
-            return packetClass.newInstance();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
+	private static Field getNMS(String path) throws Exception {
+		Field field = packetClass.getDeclaredField(path);
+		field.setAccessible(true);
+		return field;
+	}
 
-    static void sendPacket(Collection<? extends Player> players, Object packet) {
-        for (Player player : players) {
-            sendPacket(player, packet);
-        }
-    }
+	static Object createPacket() {
+		try {
+			return packetClass.newInstance();
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
 
-    static void sendPacket(Player player, Object packet) {
-        try {
-            Object nmsPlayer = getHandle.invoke(player);
-            Object connection = playerConnection.get(nmsPlayer);
-            sendPacket.invoke(connection, packet);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+	static void sendPacket(Collection<? extends Player> players, Object packet) {
+		for (Player player : players) {
+			sendPacket(player, packet);
+		}
+	}
+
+	static void sendPacket(Player player, Object packet) {
+		try {
+			Object nmsPlayer = getHandle.invoke(player);
+			Object connection = playerConnection.get(nmsPlayer);
+			sendPacket.invoke(connection, packet);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 
 }

--- a/src/main/java/com/nametagedit/plugin/packets/PacketData.java
+++ b/src/main/java/com/nametagedit/plugin/packets/PacketData.java
@@ -7,14 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 enum PacketData {
 
-    v1_7("e", "c", "d", "a", "f", "g", "b", "NA", "NA"),
+    v1_7("e", "c", "d", "a", "f", "g", "b", "NA", "NA", "NA"),
     cauldron("field_149317_e", "field_149319_c", "field_149316_d", "field_149320_a",
-            "field_149314_f", "field_149315_g", "field_149318_b", "NA", "NA"),
-    v1_8("g", "c", "d", "a", "h", "i", "b", "NA", "e"),
-    v1_9("h", "c", "d", "a", "i", "j", "b", "f", "e"),
-    v1_10("h", "c", "d", "a", "i", "j", "b", "f", "e"),
-    v1_11("h", "c", "d", "a", "i", "j", "b", "f", "e"),
-    v1_12("h", "c", "d", "a", "i", "j", "b", "f", "e");
+            "field_149314_f", "field_149315_g", "field_149318_b", "NA", "NA", "NA"),
+    v1_8("g", "c", "d", "a", "h", "i", "b", "NA", "NA", "e"),
+    v1_9("h", "c", "d", "a", "i", "j", "b", "NA", "f", "e"),
+    v1_10("h", "c", "d", "a", "i", "j", "b", "NA", "f", "e"),
+    v1_11("h", "c", "d", "a", "i", "j", "b", "NA", "f", "e"),
+    v1_12("h", "c", "d", "a", "i", "j", "b", "NA", "f", "e"),
+	v1_13("h", "c", "d", "a", "i", "j", "b", "g", "f", "e");
 
     private String members;
     private String prefix;
@@ -23,6 +24,7 @@ enum PacketData {
     private String paramInt;
     private String packOption;
     private String displayName;
+    private String color;
     private String push;
     private String visibility;
 

--- a/src/main/java/com/nametagedit/plugin/packets/PacketWrapper.java
+++ b/src/main/java/com/nametagedit/plugin/packets/PacketWrapper.java
@@ -1,17 +1,38 @@
 package com.nametagedit.plugin.packets;
 
-import com.nametagedit.plugin.NametagHandler;
-import com.nametagedit.plugin.utils.Utils;
-import org.bukkit.entity.Player;
-
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import com.nametagedit.plugin.NametagHandler;
+import com.nametagedit.plugin.utils.Utils;
 
 public class PacketWrapper {
 
     public String error;
     private Object packet = PacketAccessor.createPacket();
+    
+	private static Constructor<?> ChatComponentText;
+	private static Class<? extends Enum> typeEnumChatFormat;
+
+	static {
+		try {
+			if (!PacketAccessor.isLegacyClient()) {
+				String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+				
+				Class<?> typeChatComponentText = Class.forName("net.minecraft.server." + version + ".ChatComponentText");
+				ChatComponentText = typeChatComponentText.getConstructor(String.class);
+				typeEnumChatFormat = (Class<? extends Enum>) Class.forName("net.minecraft.server." + version + ".EnumChatFormat");
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
 
     public PacketWrapper(String name, int param, List<String> members) {
         if (param != 3 && param != 4) {
@@ -25,10 +46,35 @@ public class PacketWrapper {
     public PacketWrapper(String name, String prefix, String suffix, int param, Collection<?> players) {
         setupDefaults(name, param);
         if (param == 0 || param == 2) {
-            try {
-                PacketAccessor.DISPLAY_NAME.set(packet, name);
-                PacketAccessor.PREFIX.set(packet, prefix);
-                PacketAccessor.SUFFIX.set(packet, suffix);
+        	try {            	            	
+				if (PacketAccessor.isLegacyClient()) {
+					PacketAccessor.DISPLAY_NAME.set(packet, name);
+					PacketAccessor.PREFIX.set(packet, prefix);
+					PacketAccessor.SUFFIX.set(packet, suffix);
+				} else {					
+					String color = ChatColor.getLastColors(prefix);
+					String colorCode = null;
+					
+					if (!color.isEmpty()) {						
+						colorCode = color.substring(color.length() - 1);
+						String chatColor = ChatColor.getByChar(colorCode).name();
+						
+						if (chatColor.equalsIgnoreCase("MAGIC"))
+							chatColor = "OBFUSCATED";
+						
+						Enum<?> colorEnum = Enum.valueOf(typeEnumChatFormat, chatColor);
+						PacketAccessor.TEAM_COLOR.set(packet, colorEnum);
+					}
+					
+					PacketAccessor.DISPLAY_NAME.set(packet, ChatComponentText.newInstance(name));
+					PacketAccessor.PREFIX.set(packet, ChatComponentText.newInstance(prefix));
+					
+					if (colorCode != null)
+						suffix = ChatColor.getByChar(colorCode) + suffix;
+					
+					PacketAccessor.SUFFIX.set(packet, ChatComponentText.newInstance(suffix));
+				}
+				
                 PacketAccessor.PACK_OPTION.set(packet, 1);
 
                 if (PacketAccessor.VISIBILITY != null) {

--- a/src/main/java/com/nametagedit/plugin/storage/database/tasks/PlayerLoader.java
+++ b/src/main/java/com/nametagedit/plugin/storage/database/tasks/PlayerLoader.java
@@ -1,21 +1,22 @@
 package com.nametagedit.plugin.storage.database.tasks;
 
-import com.nametagedit.plugin.NametagHandler;
-import com.nametagedit.plugin.api.data.PlayerData;
-import com.nametagedit.plugin.api.events.NametagFirstLoadedEvent;
-import com.nametagedit.plugin.storage.database.DatabaseConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import lombok.AllArgsConstructor;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import com.nametagedit.plugin.NametagHandler;
+import com.nametagedit.plugin.api.data.PlayerData;
+import com.nametagedit.plugin.storage.database.DatabaseConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class PlayerLoader extends BukkitRunnable {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: NametagEdit
 main: com.nametagedit.plugin.NametagEdit
-version: 4.2.1
+version: 4.3.0
 authors: [sgtcaze, Cory]
 soft-depend: [zPermissions, PermissionsEX, GroupManager, LuckPerms, LibsDisguises]
 commands:


### PR DESCRIPTION
Backwards compatible with previous version as well as 1.13.x

Since the player name color is now specified directly on 1.13+ via the team name, only one color code can be applied. The code will apply the player team/name color from the last color code from the prefix and also apply it to the suffix (if not overwritten by another color code in the suffix already).

For example, if you have a prefix "&dMod ", by default that will also make the player name/team light purple also. If you had the prefix "&d&lMod ", that will by default make it bold instead. If you wanted the player name/team to then by red you would do "&d&lMod &c" and the last color code in the prefix will be applied to the player name/team. It will also apply it to the suffix if no other color code is specified there also.