### PR TITLE
Unregister LuckPerms hook listener when NTE disables

### DIFF
--- a/src/main/java/com/nametagedit/plugin/hooks/HookLuckPerms.java
+++ b/src/main/java/com/nametagedit/plugin/hooks/HookLuckPerms.java
@@ -16,9 +16,8 @@ public class HookLuckPerms implements Listener {
 
     public HookLuckPerms(NametagHandler handler) {
         this.handler = handler;
-        LuckPerms api = LuckPermsProvider.get();
-        EventBus eventBus = api.getEventBus();
-        eventBus.subscribe(UserDataRecalculateEvent.class, this::onUserDataRecalculateEvent);
+        EventBus eventBus = Bukkit.getServicesManager().load(LuckPerms.class).getEventBus();
+        eventBus.subscribe(handler.getPlugin(), UserDataRecalculateEvent.class, this::onUserDataRecalculateEvent);
     }
 
     private void onUserDataRecalculateEvent(UserDataRecalculateEvent event) {


### PR DESCRIPTION
An unfortunate side effect of using a separate event bus is that LuckPerms event listeners are not unregistered automatically when plugins disable, unless the plugin instance is passed upon registration.

This PR fixes that, and prevents errors when NTE is reloaded using PlugMan, for example.