### PR TITLE
Persistant API methods

### DIFF
--- a/src/main/java/com/nametagedit/plugin/api/INametagApi.java
+++ b/src/main/java/com/nametagedit/plugin/api/INametagApi.java
@@ -1,6 +1,5 @@
 package com.nametagedit.plugin.api;
 
-import com.nametagedit.plugin.NametagHandler;
 import com.nametagedit.plugin.api.data.FakeTeam;
 import com.nametagedit.plugin.api.data.GroupData;
 import com.nametagedit.plugin.api.data.Nametag;
@@ -167,4 +166,38 @@ public interface INametagApi {
      * @param loggedIn is the player logged in
      */
     void applyTagToPlayer(Player player, boolean loggedIn);
+
+    /**
+     * Updates a players prefix
+     * <p>
+     * Note: Does affect memory. Automatically applies tags to player
+     * so no applyTags call is necessary
+     * </p>
+     * @param target name of the player to update tag of
+     * @param prefix prefix to change to
+     */
+    void updatePlayerPrefix(String target, String prefix);
+
+    /**
+     * Updates a players suffix
+     * <p>
+     * Note: Does affect memory. Automatically applies tags to player
+     * so no applyTags call is necessary
+     * </p>
+     * @param target name of the player to update tag of
+     * @param suffix suffix to change to
+     */
+    void updatePlayerSuffix(String target, String suffix);
+
+    /**
+     * Updates a players nametag
+     * <p>
+     * Note: Does affect memory. Automatically applies tags to player
+     * so no applyTags call is necessary
+     * </p>
+     * @param target name of the player to update tag of
+     * @param prefix prefix to set to
+     * @param suffix suffix to set to
+     */
+    void updatePlayerNametag(String target, String prefix, String suffix);
 }

--- a/src/main/java/com/nametagedit/plugin/api/NametagAPI.java
+++ b/src/main/java/com/nametagedit/plugin/api/NametagAPI.java
@@ -1,6 +1,5 @@
 package com.nametagedit.plugin.api;
 
-import com.nametagedit.plugin.NametagEdit;
 import com.nametagedit.plugin.NametagHandler;
 import com.nametagedit.plugin.NametagManager;
 import com.nametagedit.plugin.api.data.FakeTeam;
@@ -106,6 +105,21 @@ public final class NametagAPI implements INametagApi {
     @Override
     public void applyTagToPlayer(Player player, boolean loggedIn) {
         handler.applyTagToPlayer(player,loggedIn);
+    }
+
+    @Override
+    public void updatePlayerPrefix(String target, String prefix) {
+        handler.save(target, NametagEvent.ChangeType.PREFIX, prefix);
+    }
+
+    @Override
+    public void updatePlayerSuffix(String target, String suffix) {
+        handler.save(target, NametagEvent.ChangeType.SUFFIX, suffix);
+    }
+
+    @Override
+    public void updatePlayerNametag(String target, String prefix, String suffix) {
+        handler.save(target, prefix, suffix);
     }
 
     /**


### PR DESCRIPTION
Adds a few API methods to update a players tag permanently. Will be looking to do the same with groups shortly, but have seen a few people attempting to do this so I thought I would make a PR