### PR TITLE
Check if port is set before adding to Hikari props

### DIFF
--- a/src/main/java/com/nametagedit/plugin/storage/database/DatabaseConfig.java
+++ b/src/main/java/com/nametagedit/plugin/storage/database/DatabaseConfig.java
@@ -49,7 +49,9 @@ public class DatabaseConfig implements AbstractConfig {
         hikari.addDataSourceProperty("requireSSL", false);
         hikari.addDataSourceProperty("verifyServerCertificate", false);
         hikari.addDataSourceProperty("serverName", config.getString("MySQL.Hostname"));
-        hikari.addDataSourceProperty("port", config.getString("MySQL.Port"));
+        if (config.isSet("MySQL.Port")) {
+            hikari.addDataSourceProperty("port", config.getString("MySQL.Port"));
+        }
         hikari.addDataSourceProperty("databaseName", config.getString("MySQL.Database"));
         hikari.addDataSourceProperty("user", config.getString("MySQL.Username"));
         hikari.addDataSourceProperty("password", config.getString("MySQL.Password"));


### PR DESCRIPTION
In my specific use case I needed to be able to unset the port in the config.yml to connect to the MySQL host. Quick check if the config value is set, if so add the port. 