### PR TITLE
Fix and improve a few things.

### DIFF
--- a/src/main/java/com/nametagedit/plugin/packets/PacketAccessor.java
+++ b/src/main/java/com/nametagedit/plugin/packets/PacketAccessor.java
@@ -11,7 +11,8 @@ import java.util.List;
 
 class PacketAccessor {
 
-    public static final String VERSION = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+    protected static final String VERSION = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+    protected static final int MINOR_VERSION = Integer.parseInt(VERSION.split("_")[1]);
 
     private static final List<String> legacyVersions = Arrays.asList("v1_7_R1", "v1_7_R2", "v1_7_R3", "v1_7_R4", "v1_8_R1", "v1_8_R2", "v1_8_R3", "v1_9_R1", "v1_9_R2", "v1_10_R1", "v1_11_R1", "v1_12_R1");
     private static boolean CAULDRON_SERVER = false;
@@ -142,15 +143,15 @@ class PacketAccessor {
     }
 
     public static boolean isParamsVersion() {
-        return Integer.parseInt(PacketAccessor.VERSION.split("_")[1]) >= 17;
+        return MINOR_VERSION >= 17;
     }
 
     private static boolean isPushVersion() {
-        return Integer.parseInt(PacketAccessor.VERSION.split("_")[1]) >= 9;
+        return MINOR_VERSION >= 9;
     }
 
     private static boolean isVisibilityVersion() {
-        return Integer.parseInt(PacketAccessor.VERSION.split("_")[1]) >= 8;
+        return MINOR_VERSION >= 8;
     }
 
     private static Field getNMS(String path) throws Exception {
@@ -180,13 +181,10 @@ class PacketAccessor {
     }
 
     static Object createPacketParams() {
-        if (!isParamsVersion()) {
-            return null;
-        }
 
         try {
             if (!isParamsVersion()) {
-                return packetParamsClass.newInstance();
+                return null;
             } else {
                 return ALLOCATE_INSTANCE.invoke(UNSAFE, packetParamsClass);
             }

--- a/src/main/java/com/nametagedit/plugin/packets/PacketWrapper.java
+++ b/src/main/java/com/nametagedit/plugin/packets/PacketWrapper.java
@@ -2,7 +2,6 @@ package com.nametagedit.plugin.packets;
 
 import com.nametagedit.plugin.NametagHandler;
 import com.nametagedit.plugin.utils.Utils;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -25,12 +24,10 @@ public class PacketWrapper {
     static {
         try {
             if (!PacketAccessor.isLegacyVersion()) {
-                final String version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-
                 if (!PacketAccessor.isParamsVersion()) {
-                    Class<?> typeChatComponentText = Class.forName("net.minecraft.server." + version + ".ChatComponentText");
+                    Class<?> typeChatComponentText = Class.forName("net.minecraft.server." + PacketAccessor.VERSION + ".ChatComponentText");
                     ChatComponentText = typeChatComponentText.getConstructor(String.class);
-                    typeEnumChatFormat = (Class<? extends Enum>) Class.forName("net.minecraft.server." + version + ".EnumChatFormat");
+                    typeEnumChatFormat = (Class<? extends Enum>) Class.forName("net.minecraft.server." + PacketAccessor.VERSION + ".EnumChatFormat");
                 } else {
                     // 1.17+
                     Class<?> typeChatComponentText = Class.forName("net.minecraft.network.chat.ChatComponentText");


### PR DESCRIPTION
~~Currently waiting to fix the issue below:~~

> ```
> 4.06 00:16:06 [Server] ERROR java.lang.NullPointerException
> 14.06 00:16:06 [Server] WARN java.lang.NullPointerException
> 14.06 00:16:06 [Server] WARN at net.minecraft.server.v1_16_R3.PacketDataSerializer.a(PacketDataSerializer.java:192)
> 14.06 00:16:06 [Server] WARN at net.minecraft.server.v1_16_R3.PacketPlayOutScoreboardTeam.b(PacketPlayOutScoreboardTeam.java:116)
> 14.06 00:16:06 [Server] WARN at net.minecraft.server.v1_16_R3.PacketEncoder.encode(PacketEncoder.java:46)
> 14.06 00:16:06 [Server] WARN at net.minecraft.server.v1_16_R3.PacketEncoder.encode(PacketEncoder.java:15)
> 14.06 00:16:06 [Server] WARN at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:790)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:758)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:808)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:294)
> 14.06 00:16:06 [Server] WARN at net.minecraft.server.v1_16_R3.NetworkManager.lambda$b$6(NetworkManager.java:323)
> 14.06 00:16:06 [Server] WARN at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
> 14.06 00:16:06 [Server] WARN at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
> 14.06 00:16:06 [Server] WARN at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
> 14.06 00:16:06 [Server] WARN at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
> 14.06 00:16:06 [Server] WARN at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
> 14.06 00:16:06 [Server] WARN at java.base/java.lang.Thread.run(Thread.java:829)
> ```
> 
> NPE

