### PR TITLE
Fix unrelocated libraries (HikariCP and Slf4j)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,16 @@
                                     <include>org.bstats.bStats-Metrics:*</include>
                                 </includes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>com.nametagedit.plugin.shaded.org.slf4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer</pattern>
+                                    <shadedPattern>com.nametagedit.plugin.shaded.com.zaxxer</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fixes the longstanding bug #636 , whereby NametagEdit's libraries are liable to conflict with those of other plugins.